### PR TITLE
fix: allow localized hotkey names and combo hold

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ python -m cursor_tool              # start the recorder and transcriber
 
 When configuring, press the desired key combinations (or hit Enter to keep
 the current value) and the chosen hotkeys will be displayed in a readable
-form. If the ``keyboard`` package is unavailable, you can type the
-shortcuts manually and the tool falls back to ``pynput`` for handling
-them.
+form.  Manual input also works and common localised names such as
+``strg`` (``ctrl``) or ``umschalt`` (``shift``) are automatically
+normalised.  If the ``keyboard`` package is unavailable, the tool falls
+back to ``pynput`` for handling them.
 
 The default configuration is stored in ``~/.cursor_tool.json``.  During
 runtime the fast model's output is injected directly at the cursor while

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ pip install -r requirements.txt
 python -m cursor_tool --configure  # set up hotkeys and model names
 python -m cursor_tool              # start the recorder and transcriber
 ```
+After launching, the command line displays which hotkeys to use and prints the
+transcription once recording stops.
 
 When configuring, press the desired key combinations (or hit Enter to keep
 the current value) and the chosen hotkeys will be displayed in a readable

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ corrections.
 * Global hotkeys to start/stop recording or hold-to-talk
 * Real-time transcription with a fast model
 * Higher quality corrections in the background
-* Visual indicator overlay with optional beep sounds
+* Small overlay shows a red dot when idle and turns green while recording
 * Persistent configuration for hotkeys, model names and chunk length
 * Helper to package the tool as a standalone Windows executable
 
@@ -27,6 +27,7 @@ pip install -r requirements.txt
 ```bash
 python -m cursor_tool --configure  # set up hotkeys and model names
 python -m cursor_tool              # start the recorder and transcriber
+python -m cursor_tool --verbose    # same but with debug logging
 ```
 After launching, the command line displays which hotkeys to use and prints the
 transcription once recording stops.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ corrections.
 * Real-time transcription with a fast model
 * Higher quality corrections in the background
 * Small overlay shows a red dot when idle and turns green while recording
-* Persistent configuration for hotkeys, model names and chunk length
+* Persistent configuration for hotkeys, model names, chunk length and language
 * Helper to package the tool as a standalone Windows executable
 
 ## Installation
@@ -25,12 +25,13 @@ pip install -r requirements.txt
 ## Usage
 
 ```bash
-python -m cursor_tool --configure  # set up hotkeys and model names
+python -m cursor_tool --configure  # set up hotkeys, model names and language
 python -m cursor_tool              # start the recorder and transcriber
 python -m cursor_tool --verbose    # same but with debug logging
 ```
 After launching, the command line displays which hotkeys to use and prints the
-transcription once recording stops.
+transcription once recording stops. A small always-on-top indicator in the top-left
+corner turns green while recording.
 
 When configuring, press the desired key combinations (or hit Enter to keep
 the current value) and the chosen hotkeys will be displayed in a readable
@@ -42,6 +43,9 @@ back to ``pynput`` for handling them.
 The default configuration is stored in ``~/.cursor_tool.json``.  During
 runtime the fast model's output is injected directly at the cursor while
 the precise model refines the text in-place.
+
+By default the transcription language is set to German; the configuration
+prompt allows choosing a different language if needed.
 
 ## Packaging
 

--- a/cursor_tool/__init__.py
+++ b/cursor_tool/__init__.py
@@ -15,7 +15,7 @@ from .config import Config, default_config_path
 from .cli import run, configure
 from .models import load_faster_whisper
 from .active_window import is_text_field_focused
-from .indicator import RecordingIndicator
+from .indicator import RecordingIndicator, indicator
 from .packager import build_executable
 
 __all__ = [
@@ -29,6 +29,7 @@ __all__ = [
     "insert_text",
     "is_text_field_focused",
     "RecordingIndicator",
+    "indicator",
     "Config",
     "default_config_path",
     "configure",

--- a/cursor_tool/__main__.py
+++ b/cursor_tool/__main__.py
@@ -22,12 +22,17 @@ def main(argv: list[str] | None = None) -> None:
         action="store_true",
         help="run the interactive configuration wizard",
     )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="enable debug logging",
+    )
     args = parser.parse_args(argv)
 
     if args.configure:
         configure()
     else:
-        run()
+        run(verbose=args.verbose)
 
 
 if __name__ == "__main__":  # pragma: no cover - exercised via tests

--- a/cursor_tool/active_window.py
+++ b/cursor_tool/active_window.py
@@ -23,6 +23,10 @@ EDIT_CLASSES: Iterable[str] = {
     "Edit",
     "RichEdit20A",
     "RichEdit20W",
+    # common top-level windows that often host editable fields
+    "Chrome_WidgetWin_1",  # Chrome/Edge
+    "MozillaWindowClass",  # Firefox
+    "Notepad",
 }
 
 

--- a/cursor_tool/cli.py
+++ b/cursor_tool/cli.py
@@ -75,6 +75,7 @@ def configure(
     fast_model: Optional[str] = None,
     precise_model: Optional[str] = None,
     chunk_seconds: Optional[float] = None,
+    language: Optional[str] = None,
 ) -> Config:
     """Interactively update and persist user configuration."""
 
@@ -91,6 +92,7 @@ def configure(
     if chunk_seconds is None:
         chunk_input = prompt("Chunk length (seconds)", str(cfg.chunk_seconds))
         chunk_seconds = float(chunk_input)
+    language = language or prompt("Language", cfg.language)
 
     cfg = Config(
         toggle_key=toggle_key,
@@ -98,6 +100,7 @@ def configure(
         fast_model=fast_model,
         precise_model=precise_model,
         chunk_seconds=chunk_seconds,
+        language=language,
     )
     cfg.save(path)
     return cfg
@@ -115,8 +118,8 @@ def run(
     cfg = Config.load()
     logging.debug("configuration loaded: %s", cfg)
     print("Loading models...", flush=True)
-    fast = fast_model or load_faster_whisper(cfg.fast_model)
-    precise = precise_model or load_faster_whisper(cfg.precise_model)
+    fast = fast_model or load_faster_whisper(cfg.fast_model, language=cfg.language)
+    precise = precise_model or load_faster_whisper(cfg.precise_model, language=cfg.language)
     indicator.show()
     register_hotkeys(cfg.toggle_key, cfg.hold_key)
     msg = f"Press {cfg.toggle_key} to start/stop recording"

--- a/cursor_tool/cli.py
+++ b/cursor_tool/cli.py
@@ -17,6 +17,7 @@ except Exception:  # pragma: no cover
     keyboard = None  # type: ignore
 
 from .config import Config
+from .hotkeys import normalize_hotkey
 from .pipeline import transcribe_from_recorder
 from .recorder import recorder, register_hotkeys
 from .transcriber import DoubleTranscriber, Model
@@ -24,12 +25,36 @@ from .typer import insert_text
 from .models import load_faster_whisper
 
 
+def _flush_stdin() -> None:
+    """Best-effort removal of pending characters from ``stdin``."""
+
+    try:  # Windows
+        import msvcrt
+
+        while msvcrt.kbhit():
+            msvcrt.getwch()
+    except Exception:
+        try:  # POSIX
+            import sys
+            import termios
+
+            termios.tcflush(sys.stdin, termios.TCIFLUSH)
+        except Exception:
+            pass
+
+
 def prompt_hotkey(label: str, current: str) -> str:
-    """Prompt user to press a hotkey and return its string representation."""
+    """Prompt the user for a hotkey and normalise the result.
+
+    The function prefers ``keyboard.read_hotkey`` so the user can simply press
+    the desired combination.  When ``keyboard`` isn't available or the user
+    types a value manually we still normalise common localised key names such as
+    ``strg`` or ``umschalt``.
+    """
 
     if keyboard is None:
         # Fallback to manual typing when ``keyboard`` isn't installed
-        return input(f"{label} [{current}]: ") or current
+        return normalize_hotkey(input(f"{label} [{current}]: ") or current)
 
     print(f"{label} [{current}]: ", end="", flush=True)
     hotkey = keyboard.read_hotkey(suppress=False)
@@ -37,7 +62,8 @@ def prompt_hotkey(label: str, current: str) -> str:
         print()
         return current
     print(hotkey)
-    return hotkey
+    _flush_stdin()
+    return normalize_hotkey(hotkey)
 
 
 def configure(
@@ -53,10 +79,11 @@ def configure(
     cfg = Config.load(path)
 
     def prompt(label: str, current: str) -> str:
+        _flush_stdin()
         return input(f"{label} [{current}]: ") or current
 
-    toggle_key = toggle_key or prompt_hotkey("Toggle hotkey", cfg.toggle_key)
-    hold_key = hold_key or prompt_hotkey("Hold hotkey", cfg.hold_key)
+    toggle_key = normalize_hotkey(toggle_key or prompt_hotkey("Toggle hotkey", cfg.toggle_key))
+    hold_key = normalize_hotkey(hold_key or prompt_hotkey("Hold hotkey", cfg.hold_key))
     fast_model = fast_model or prompt("Fast model", cfg.fast_model)
     precise_model = precise_model or prompt("Precise model", cfg.precise_model)
     if chunk_seconds is None:

--- a/cursor_tool/cli.py
+++ b/cursor_tool/cli.py
@@ -105,8 +105,15 @@ def run(fast_model: Model | None = None, precise_model: Model | None = None) -> 
     """Load config, register hotkeys and process audio once recording stops."""
 
     cfg = Config.load()
-    register_hotkeys(cfg.toggle_key, cfg.hold_key)
+    print("Loading models...", flush=True)
     fast = fast_model or load_faster_whisper(cfg.fast_model)
     precise = precise_model or load_faster_whisper(cfg.precise_model)
+    register_hotkeys(cfg.toggle_key, cfg.hold_key)
+    msg = f"Press {cfg.toggle_key} to start/stop recording"
+    if cfg.hold_key and cfg.hold_key != cfg.toggle_key:
+        msg += f" or hold {cfg.hold_key} to talk"
+    print(msg + ".")
     transcriber = DoubleTranscriber(fast, precise, on_fast=insert_text)
-    return transcribe_from_recorder(recorder, transcriber)
+    text = transcribe_from_recorder(recorder, transcriber)
+    print(text)
+    return text

--- a/cursor_tool/cli.py
+++ b/cursor_tool/cli.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Optional
+import logging
 
 try:  # pragma: no cover - used only when configuring hotkeys
     import keyboard
@@ -23,6 +24,7 @@ from .recorder import recorder, register_hotkeys
 from .transcriber import DoubleTranscriber, Model
 from .typer import insert_text
 from .models import load_faster_whisper
+from .indicator import indicator
 
 
 def _flush_stdin() -> None:
@@ -101,13 +103,21 @@ def configure(
     return cfg
 
 
-def run(fast_model: Model | None = None, precise_model: Model | None = None) -> str:
+def run(
+    fast_model: Model | None = None,
+    precise_model: Model | None = None,
+    *,
+    verbose: bool = False,
+) -> str:
     """Load config, register hotkeys and process audio once recording stops."""
 
+    logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO)
     cfg = Config.load()
+    logging.debug("configuration loaded: %s", cfg)
     print("Loading models...", flush=True)
     fast = fast_model or load_faster_whisper(cfg.fast_model)
     precise = precise_model or load_faster_whisper(cfg.precise_model)
+    indicator.show()
     register_hotkeys(cfg.toggle_key, cfg.hold_key)
     msg = f"Press {cfg.toggle_key} to start/stop recording"
     if cfg.hold_key and cfg.hold_key != cfg.toggle_key:

--- a/cursor_tool/config.py
+++ b/cursor_tool/config.py
@@ -10,6 +10,7 @@ DEFAULT_HOLD = "ctrl+space"
 DEFAULT_FAST_MODEL = "tiny"
 DEFAULT_PRECISE_MODEL = "base"
 DEFAULT_CHUNK_SECONDS = 5.0
+DEFAULT_LANGUAGE = "de"
 
 
 def default_config_path() -> Path:
@@ -26,6 +27,7 @@ class Config:
     fast_model: str = DEFAULT_FAST_MODEL
     precise_model: str = DEFAULT_PRECISE_MODEL
     chunk_seconds: float = DEFAULT_CHUNK_SECONDS
+    language: str = DEFAULT_LANGUAGE
 
     @classmethod
     def load(cls, path: Optional[Path] = None) -> "Config":

--- a/cursor_tool/hotkeys.py
+++ b/cursor_tool/hotkeys.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""Utilities for normalising hotkey strings.
+
+The :mod:`keyboard` package expects English key names like ``ctrl`` and
+``shift``.  Users on non-English layouts often enter localised names such as
+``strg`` or ``umschalt`` which would otherwise raise a ``ValueError``.
+
+``normalize_hotkey`` replaces known localised aliases with the canonical names
+understood by the ``keyboard`` library.
+"""
+
+from typing import Iterable, Optional
+
+# mapping of common non-English key names to the values expected by ``keyboard``
+KEY_ALIASES = {
+    "strg": "ctrl",
+    "steuerung": "ctrl",
+    "control": "ctrl",
+    "umschalt": "shift",
+    "shift": "shift",
+    "altgr": "alt gr",
+    "alt": "alt",
+    "option": "alt",
+    "win": "windows",
+    "meta": "windows",
+}
+
+
+def _normalize_part(part: str) -> Optional[str]:
+    """Return normalised version of *part* or ``None`` if invalid."""
+
+    cleaned = part.strip().lower().strip("\"'` ")
+    if not cleaned or not any(ch.isalnum() for ch in cleaned):
+        return None
+    return KEY_ALIASES.get(cleaned, cleaned)
+
+def normalize_hotkey(hotkey: str | Iterable[str]) -> str:
+    """Return *hotkey* with known aliases replaced by canonical names."""
+    if isinstance(hotkey, str):
+        parts = hotkey.split("+")
+    else:  # pragma: no cover - not used but keeps function generic
+        parts = list(hotkey)
+
+    normalized: list[str] = []
+    for p in parts:
+        norm = _normalize_part(p)
+        if norm:
+            normalized.append(norm)
+    return "+".join(normalized)

--- a/cursor_tool/indicator.py
+++ b/cursor_tool/indicator.py
@@ -18,7 +18,10 @@ class RecordingIndicator:
         self._beep = beep
         self._thread: threading.Thread | None = None
         self._root: "tk.Tk" | None = None
+        self._canvas: "tk.Canvas" | None = None
+        self._oval: int | None = None
         self._visible = False
+        self._color = "red"
 
     # sound helpers -----------------------------------------------------
     def _play_start(self) -> None:
@@ -33,37 +36,52 @@ class RecordingIndicator:
     def _run(self) -> None:
         if not tk:  # pragma: no cover - no GUI available
             return
-        root = tk.Tk()
+        try:
+            root = tk.Tk()
+        except Exception:  # pragma: no cover - e.g. no DISPLAY
+            return
         self._root = root
         root.overrideredirect(True)
         root.attributes("-topmost", True)
         canvas = tk.Canvas(root, width=20, height=20, highlightthickness=0)
         canvas.pack()
-        canvas.create_oval(2, 2, 18, 18, fill="green", outline="")
+        self._canvas = canvas
+        self._oval = canvas.create_oval(2, 2, 18, 18, fill=self._color, outline="")
         root.mainloop()
+
+    def _update(self, color: str) -> None:
+        if not self._root or not self._canvas or self._oval is None:
+            return
+        self._color = color
+        def _():
+            self._canvas.itemconfig(self._oval, fill=color)
+        self._root.after(0, _)
 
     # public API --------------------------------------------------------
     @property
     def visible(self) -> bool:
         return self._visible
 
-    def start(self) -> None:
-        """Show indicator and play start sound."""
+    def show(self) -> None:
+        """Create the overlay if not yet visible."""
         if self._visible:
             return
         self._visible = True
         if tk:
             self._thread = threading.Thread(target=self._run, daemon=True)
             self._thread.start()
+
+    def start(self) -> None:
+        """Turn the indicator green and play start sound."""
+        self.show()
+        self._update("green")
         self._play_start()
 
     def stop(self) -> None:
-        """Hide indicator and play stop sound."""
-        if not self._visible:
-            return
-        self._visible = False
-        if self._root:
-            self._root.quit()
-            self._root = None
-        self._thread = None
+        """Turn the indicator red and play stop sound."""
+        self.show()
+        self._update("red")
         self._play_stop()
+
+
+indicator = RecordingIndicator()

--- a/cursor_tool/indicator.py
+++ b/cursor_tool/indicator.py
@@ -14,7 +14,7 @@ except Exception:  # pragma: no cover - winsound only on Windows
 class RecordingIndicator:
     """Small overlay and optional beeps indicating recording state."""
 
-    def __init__(self, *, beep: bool = True) -> None:
+    def __init__(self, *, beep: bool = False) -> None:
         self._beep = beep
         self._thread: threading.Thread | None = None
         self._root: "tk.Tk" | None = None
@@ -43,7 +43,13 @@ class RecordingIndicator:
         self._root = root
         root.overrideredirect(True)
         root.attributes("-topmost", True)
-        canvas = tk.Canvas(root, width=20, height=20, highlightthickness=0)
+        root.geometry("20x20+10+10")
+        root.configure(bg="black")
+        try:
+            root.wm_attributes("-transparentcolor", "black")
+        except Exception:
+            pass
+        canvas = tk.Canvas(root, width=20, height=20, highlightthickness=0, bg="black")
         canvas.pack()
         self._canvas = canvas
         self._oval = canvas.create_oval(2, 2, 18, 18, fill=self._color, outline="")

--- a/cursor_tool/models.py
+++ b/cursor_tool/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from .transcriber import Model
 
 
-def load_faster_whisper(name: str, device: str = "cpu") -> Model:
+def load_faster_whisper(name: str, device: str = "cpu", *, language: str = "de") -> Model:
     """Return a callable that transcribes audio with ``faster-whisper``.
 
     The returned function accepts raw PCM ``bytes`` and returns the
@@ -31,7 +31,7 @@ def load_faster_whisper(name: str, device: str = "cpu") -> Model:
 
             ints = pyarray.array("h", audio)
             array = [i / 32768.0 for i in ints]
-        segments, _ = model.transcribe(array)
+        segments, _ = model.transcribe(array, language=language)
         return " ".join(seg.text.strip() for seg in segments)
 
     return _transcribe

--- a/cursor_tool/recorder.py
+++ b/cursor_tool/recorder.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import queue
 from typing import Optional
+import logging
 
 try:  # pragma: no cover - these are patched in tests
     import sounddevice as sd
@@ -32,6 +33,7 @@ except Exception:  # pragma: no cover
     pynput_keyboard = None  # type: ignore
 
 from .hotkeys import normalize_hotkey
+from .indicator import indicator
 
 
 class Recorder:
@@ -66,6 +68,8 @@ class Recorder:
         )
         self._stream.start()
         self.is_recording = True
+        logging.debug("recording started")
+        indicator.start()
 
     def stop_recording(self) -> None:
         """Stop and close the microphone stream."""
@@ -77,6 +81,8 @@ class Recorder:
             self._stream.close()
             self._stream = None
         self.is_recording = False
+        logging.debug("recording stopped")
+        indicator.stop()
         # Signal consumers that no more audio will arrive
         self.queue.put(None)
 
@@ -92,6 +98,7 @@ class Recorder:
         """Register global hotkeys for controlling the recorder."""
         toggle = normalize_hotkey(toggle)
         hold = normalize_hotkey(hold) if hold else None
+        logging.debug("register hotkeys toggle=%s hold=%s", toggle, hold)
 
         if keyboard is not None:
             keyboard.add_hotkey(toggle, self.toggle_recording)

--- a/cursor_tool/recorder.py
+++ b/cursor_tool/recorder.py
@@ -31,6 +31,8 @@ try:  # pragma: no cover
 except Exception:  # pragma: no cover
     pynput_keyboard = None  # type: ignore
 
+from .hotkeys import normalize_hotkey
+
 
 class Recorder:
     """Manage an input stream and hotkey registration."""
@@ -88,11 +90,14 @@ class Recorder:
 
     def register_hotkeys(self, toggle: str, hold: Optional[str] = None) -> None:
         """Register global hotkeys for controlling the recorder."""
+        toggle = normalize_hotkey(toggle)
+        hold = normalize_hotkey(hold) if hold else None
+
         if keyboard is not None:
             keyboard.add_hotkey(toggle, self.toggle_recording)
             if hold:
-                keyboard.on_press_key(hold, lambda _: self.start_recording())
-                keyboard.on_release_key(hold, lambda _: self.stop_recording())
+                keyboard.add_hotkey(hold, self.start_recording)
+                keyboard.add_hotkey(hold, self.stop_recording, trigger_on_release=True)
             return
 
         if pynput_keyboard is None:  # pragma: no cover

--- a/cursor_tool/recorder.py
+++ b/cursor_tool/recorder.py
@@ -101,10 +101,22 @@ class Recorder:
         logging.debug("register hotkeys toggle=%s hold=%s", toggle, hold)
 
         if keyboard is not None:
-            keyboard.add_hotkey(toggle, self.toggle_recording)
+            keyboard.add_hotkey(
+                toggle, self.toggle_recording, suppress=True, trigger_on_release=True
+            )
             if hold:
-                keyboard.add_hotkey(hold, self.start_recording)
-                keyboard.add_hotkey(hold, self.stop_recording, trigger_on_release=True)
+                def press_cb(_event):
+                    if not self._hold_active:
+                        self._hold_active = True
+                        self.start_recording()
+
+                def release_cb(_event):
+                    if self._hold_active:
+                        self._hold_active = False
+                        self.stop_recording()
+
+                keyboard.on_press_key(hold, press_cb, suppress=True)
+                keyboard.on_release_key(hold, release_cb, suppress=True)
             return
 
         if pynput_keyboard is None:  # pragma: no cover

--- a/cursor_tool/typer.py
+++ b/cursor_tool/typer.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 try:  # pragma: no cover - patched in tests
     import keyboard
 except Exception:  # pragma: no cover
@@ -25,7 +27,9 @@ def insert_text(text: str) -> None:
     """
 
     if not is_text_field_focused():  # pragma: no branch - simple guard
+        logging.debug("no text field focused; skipping insertion")
         return
+    logging.debug("inserting text: %r", text)
     if keyboard is not None:
         keyboard.write(text)
         return

--- a/tests/test_active_window.py
+++ b/tests/test_active_window.py
@@ -15,3 +15,8 @@ def test_is_text_field_focused_true(monkeypatch):
 def test_is_text_field_focused_false(monkeypatch):
     monkeypatch.setattr(aw, "_get_foreground_class", lambda: "Button", raising=False)
     assert not is_text_field_focused()
+
+
+def test_is_text_field_focused_browser(monkeypatch):
+    monkeypatch.setattr(aw, "_get_foreground_class", lambda: "Chrome_WidgetWin_1", raising=False)
+    assert is_text_field_focused()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ import importlib
 import sys
 import types
 from pathlib import Path
+from io import StringIO
 
 import pytest
 
@@ -26,5 +27,29 @@ def test_prompt_hotkey_with_keyboard(monkeypatch, capsys):
 
 def test_prompt_hotkey_fallback(monkeypatch):
     cli_mod = reload_cli(monkeypatch, None)
-    monkeypatch.setattr("builtins.input", lambda _=None: "ctrl+y")
+    monkeypatch.setattr("builtins.input", lambda _=None: "strg+y")
     assert cli_mod.prompt_hotkey("Toggle hotkey", "ctrl+a") == "ctrl+y"
+
+
+def test_configure_consumes_trailing_enter(monkeypatch, tmp_path):
+    hotkeys = iter(["ctrl+t", "ctrl+h"])
+    dummy_keyboard = types.SimpleNamespace(read_hotkey=lambda suppress=False: next(hotkeys))
+    cli_mod = reload_cli(monkeypatch, dummy_keyboard)
+
+    stdin = StringIO("\nfast\nprecise\n4\n")
+    monkeypatch.setattr(sys, "stdin", stdin)
+
+    calls = {"n": 0}
+
+    def fake_flush():
+        if calls["n"] == 2:
+            stdin.read(1)
+        calls["n"] += 1
+
+    monkeypatch.setattr(cli_mod, "_flush_stdin", fake_flush)
+
+    cfg = cli_mod.configure(path=tmp_path / "cfg.json")
+
+    assert cfg.fast_model == "fast"
+    assert cfg.precise_model == "precise"
+    assert cfg.chunk_seconds == 4.0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,3 +53,26 @@ def test_configure_consumes_trailing_enter(monkeypatch, tmp_path):
     assert cfg.fast_model == "fast"
     assert cfg.precise_model == "precise"
     assert cfg.chunk_seconds == 4.0
+
+
+def test_run_prints_status(monkeypatch, capsys):
+    cli_mod = reload_cli(monkeypatch, None)
+    cfg = cli_mod.Config(
+        toggle_key="ctrl+t",
+        hold_key="ctrl+h",
+        fast_model="fast",
+        precise_model="precise",
+        chunk_seconds=5.0,
+    )
+    monkeypatch.setattr(cli_mod.Config, "load", lambda path=None: cfg)
+    monkeypatch.setattr(cli_mod, "register_hotkeys", lambda t, h: None)
+    monkeypatch.setattr(cli_mod, "load_faster_whisper", lambda name: (lambda _: name))
+    monkeypatch.setattr(
+        cli_mod, "transcribe_from_recorder", lambda rec, transcriber: "result"
+    )
+    text = cli_mod.run()
+    assert text == "result"
+    out = capsys.readouterr().out
+    assert "Loading models" in out
+    assert "Press ctrl+t" in out
+    assert "result" in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,8 @@
+from io import StringIO
 import importlib
 import sys
 import types
 from pathlib import Path
-from io import StringIO
 
 import pytest
 
@@ -36,7 +36,7 @@ def test_configure_consumes_trailing_enter(monkeypatch, tmp_path):
     dummy_keyboard = types.SimpleNamespace(read_hotkey=lambda suppress=False: next(hotkeys))
     cli_mod = reload_cli(monkeypatch, dummy_keyboard)
 
-    stdin = StringIO("\nfast\nprecise\n4\n")
+    stdin = StringIO("\nfast\nprecise\n4\nde\n")
     monkeypatch.setattr(sys, "stdin", stdin)
 
     calls = {"n": 0}
@@ -53,6 +53,7 @@ def test_configure_consumes_trailing_enter(monkeypatch, tmp_path):
     assert cfg.fast_model == "fast"
     assert cfg.precise_model == "precise"
     assert cfg.chunk_seconds == 4.0
+    assert cfg.language == "de"
 
 
 def test_run_prints_status(monkeypatch, capsys):
@@ -63,10 +64,14 @@ def test_run_prints_status(monkeypatch, capsys):
         fast_model="fast",
         precise_model="precise",
         chunk_seconds=5.0,
+        language="de",
     )
     monkeypatch.setattr(cli_mod.Config, "load", lambda path=None: cfg)
     monkeypatch.setattr(cli_mod, "register_hotkeys", lambda t, h: None)
-    monkeypatch.setattr(cli_mod, "load_faster_whisper", lambda name: (lambda _: name))
+    def fake_loader(name, *, language):
+        return lambda _: f"{name}-{language}"
+
+    monkeypatch.setattr(cli_mod, "load_faster_whisper", fake_loader)
     monkeypatch.setattr(
         cli_mod, "transcribe_from_recorder", lambda rec, transcriber: "result"
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,8 +70,11 @@ def test_run_prints_status(monkeypatch, capsys):
     monkeypatch.setattr(
         cli_mod, "transcribe_from_recorder", lambda rec, transcriber: "result"
     )
+    called = {}
+    monkeypatch.setattr(cli_mod.indicator, "show", lambda: called.setdefault("show", True))
     text = cli_mod.run()
     assert text == "result"
+    assert called["show"] is True
     out = capsys.readouterr().out
     assert "Loading models" in out
     assert "Press ctrl+t" in out

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,7 @@ def test_load_defaults(tmp_path):
     assert cfg.toggle_key == "ctrl+shift+space"
     assert cfg.fast_model == "tiny"
     assert cfg.chunk_seconds == 5.0
+    assert cfg.language == "de"
 
 def test_save_and_load(tmp_path):
     path = tmp_path / "config.json"

--- a/tests/test_hotkeys.py
+++ b/tests/test_hotkeys.py
@@ -1,0 +1,11 @@
+from cursor_tool.hotkeys import normalize_hotkey
+
+
+def test_normalize_hotkey_aliases():
+    assert normalize_hotkey("q+strg+umschalt") == "q+ctrl+shift"
+    assert normalize_hotkey("ALT+Q") == "alt+q"
+
+
+def test_normalize_hotkey_strips_punctuation():
+    assert normalize_hotkey("'+strg+umschalt") == "ctrl+shift"
+    assert normalize_hotkey("`+ALT") == "alt"

--- a/tests/test_indicator.py
+++ b/tests/test_indicator.py
@@ -23,6 +23,15 @@ def indicator_module(monkeypatch):
         def attributes(self, *_):
             pass
 
+        def geometry(self, *_):
+            pass
+
+        def configure(self, *_ , **__):
+            pass
+
+        def wm_attributes(self, *_ , **__):
+            pass
+
         def mainloop(self):
             pass
 
@@ -77,4 +86,4 @@ def test_start_stop_indicator(indicator_module):
     assert ind.visible is True
     ind.stop()
     assert ind.visible is True
-    assert beeps == [(880, 150), (440, 150)]
+    assert beeps == []

--- a/tests/test_indicator.py
+++ b/tests/test_indicator.py
@@ -1,6 +1,7 @@
 import importlib
 import sys
 import types
+from pathlib import Path
 
 import pytest
 
@@ -28,6 +29,9 @@ def indicator_module(monkeypatch):
         def quit(self):
             pass
 
+        def after(self, _delay, func):
+            func()
+
     class DummyCanvas:
         def __init__(self, *_, **__):
             pass
@@ -37,6 +41,9 @@ def indicator_module(monkeypatch):
 
         def create_oval(self, *_, **__):
             return 1
+
+        def itemconfig(self, *_ , **__):
+            pass
 
     dummy_tk.Tk = DummyRoot
     dummy_tk.Canvas = DummyCanvas
@@ -54,10 +61,13 @@ def indicator_module(monkeypatch):
     monkeypatch.setitem(sys.modules, "winsound", dummy_winsound)
     monkeypatch.setitem(sys.modules, "tkinter", dummy_tk)
     monkeypatch.setattr("threading.Thread", DummyThread)
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[1]))
     if "cursor_tool.indicator" in sys.modules:
         del sys.modules["cursor_tool.indicator"]
     module = importlib.import_module("cursor_tool.indicator")
-    return module, beeps
+    yield module, beeps
+    if "cursor_tool.indicator" in sys.modules:
+        del sys.modules["cursor_tool.indicator"]
 
 
 def test_start_stop_indicator(indicator_module):
@@ -66,5 +76,5 @@ def test_start_stop_indicator(indicator_module):
     ind.start()
     assert ind.visible is True
     ind.stop()
-    assert ind.visible is False
+    assert ind.visible is True
     assert beeps == [(880, 150), (440, 150)]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,12 +4,12 @@ from cursor_tool import __main__
 def test_run_invoked(monkeypatch):
     called = {}
 
-    def fake_run():
-        called["run"] = True
+    def fake_run(*, verbose=False):
+        called["run"] = verbose
 
     monkeypatch.setattr(__main__, "run", fake_run)
     __main__.main([])
-    assert called["run"]
+    assert called["run"] is False
 
 
 def test_configure_invoked(monkeypatch):
@@ -21,3 +21,14 @@ def test_configure_invoked(monkeypatch):
     monkeypatch.setattr(__main__, "configure", fake_configure)
     __main__.main(["--configure"])
     assert called["config"]
+
+
+def test_verbose_flag(monkeypatch):
+    called = {}
+
+    def fake_run(*, verbose=False):
+        called["verbose"] = verbose
+
+    monkeypatch.setattr(__main__, "run", fake_run)
+    __main__.main(["--verbose"])
+    assert called["verbose"] is True

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,20 +7,24 @@ from cursor_tool.models import load_faster_whisper
 
 def test_load_faster_whisper_calls_library(monkeypatch):
     fake_segments = [MagicMock(text="hi"), MagicMock(text="there")]
+    inst: dict[str, DummyModel] = {}
 
     class DummyModel:
         def __init__(self, name, device, compute_type):
+            inst["obj"] = self
             self.called_with = (name, device, compute_type)
+            self.language = None
 
-        def transcribe(self, array):
+        def transcribe(self, array, language):
+            self.language = language
             return fake_segments, None
 
-    dummy_cls = MagicMock(side_effect=DummyModel)
-    fake_module = SimpleNamespace(WhisperModel=dummy_cls)
+    fake_module = SimpleNamespace(WhisperModel=DummyModel)
     monkeypatch.setitem(sys.modules, "faster_whisper", fake_module)
 
     model = load_faster_whisper("tiny")
     result = model(b"\x00\x00")
 
-    dummy_cls.assert_called_with("tiny", device="cpu", compute_type="int8")
+    assert inst["obj"].called_with == ("tiny", "cpu", "int8")
+    assert inst["obj"].language == "de"
     assert result == "hi there"

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -30,16 +30,22 @@ def recorder_module(monkeypatch):
 
     dummy_keyboard = types.SimpleNamespace()
     callbacks: dict[str, types.FunctionType] = {}
+    params: dict[str, bool] = {}
 
-    def add_hotkey(key, cb, trigger_on_release=False):
-        if key == "ctrl+alt+r":
-            callbacks["toggle"] = cb
-        elif trigger_on_release:
-            callbacks["release"] = cb
-        else:
-            callbacks["press"] = cb
+    def add_hotkey(key, cb, suppress=False, trigger_on_release=False):
+        params["suppress"] = suppress
+        params["trigger_on_release"] = trigger_on_release
+        callbacks["toggle"] = cb
+
+    def on_press_key(key, cb, suppress=False):
+        callbacks["press"] = cb
+
+    def on_release_key(key, cb, suppress=False):
+        callbacks["release"] = cb
 
     dummy_keyboard.add_hotkey = add_hotkey
+    dummy_keyboard.on_press_key = on_press_key
+    dummy_keyboard.on_release_key = on_release_key
 
     monkeypatch.setitem(sys.modules, "sounddevice", dummy_sd)
     monkeypatch.setitem(sys.modules, "keyboard", dummy_keyboard)
@@ -47,11 +53,11 @@ def recorder_module(monkeypatch):
     if "cursor_tool.recorder" in sys.modules:
         del sys.modules["cursor_tool.recorder"]
     module = importlib.import_module("cursor_tool.recorder")
-    return module, callbacks
+    return module, callbacks, params
 
 
 def test_start_and_stop_recording(recorder_module):
-    module, _ = recorder_module
+    module, _, _ = recorder_module
     module.start_recording()
     assert module.recorder.is_recording is True
     assert module.recorder.queue.get() == b"abc"
@@ -60,17 +66,19 @@ def test_start_and_stop_recording(recorder_module):
 
 
 def test_hotkey_callbacks(recorder_module):
-    module, callbacks = recorder_module
+    module, callbacks, params = recorder_module
     module.register_hotkeys("ctrl+alt+r", "shift+s")
+    assert params["suppress"] is True
+    assert params["trigger_on_release"] is True
 
     callbacks["toggle"]()
     assert module.recorder.is_recording is True
     callbacks["toggle"]()
     assert module.recorder.is_recording is False
 
-    callbacks["press"]()
+    callbacks["press"](None)
     assert module.recorder.is_recording is True
-    callbacks["release"]()
+    callbacks["release"](None)
     assert module.recorder.is_recording is False
 
 

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -31,18 +31,15 @@ def recorder_module(monkeypatch):
     dummy_keyboard = types.SimpleNamespace()
     callbacks: dict[str, types.FunctionType] = {}
 
-    def add_hotkey(key, cb):
-        callbacks["toggle"] = cb
-
-    def on_press_key(key, cb):
-        callbacks["press"] = cb
-
-    def on_release_key(key, cb):
-        callbacks["release"] = cb
+    def add_hotkey(key, cb, trigger_on_release=False):
+        if key == "ctrl+alt+r":
+            callbacks["toggle"] = cb
+        elif trigger_on_release:
+            callbacks["release"] = cb
+        else:
+            callbacks["press"] = cb
 
     dummy_keyboard.add_hotkey = add_hotkey
-    dummy_keyboard.on_press_key = on_press_key
-    dummy_keyboard.on_release_key = on_release_key
 
     monkeypatch.setitem(sys.modules, "sounddevice", dummy_sd)
     monkeypatch.setitem(sys.modules, "keyboard", dummy_keyboard)
@@ -64,16 +61,16 @@ def test_start_and_stop_recording(recorder_module):
 
 def test_hotkey_callbacks(recorder_module):
     module, callbacks = recorder_module
-    module.register_hotkeys("ctrl+alt+r", "shift")
+    module.register_hotkeys("ctrl+alt+r", "shift+s")
 
     callbacks["toggle"]()
     assert module.recorder.is_recording is True
     callbacks["toggle"]()
     assert module.recorder.is_recording is False
 
-    callbacks["press"](None)
+    callbacks["press"]()
     assert module.recorder.is_recording is True
-    callbacks["release"](None)
+    callbacks["release"]()
     assert module.recorder.is_recording is False
 
 


### PR DESCRIPTION
## Summary
- normalize hotkeys to handle localized names and strip stray punctuation
- flush leftover input so configuration prompts appear correctly
- document and test hotkey normalization and configuration flow

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5d565136c83248d44661fe7c48706